### PR TITLE
Add `drug to gene` and `drug to disease` associations

### DIFF
--- a/config/schema_config.yaml
+++ b/config/schema_config.yaml
@@ -94,3 +94,17 @@ gene to go term association:
   source: gene
   target: go term
   input_label: GENE_TO_GO_TERM_ASSOCIATION
+
+drug to disease association:
+  is_a: association
+  represented_as: edge
+  source: drug
+  target: disease
+  input_label: DRUG_TO_DISEASE_ASSOCIATION
+
+drug to gene association:
+  is_a: association
+  represented_as: edge
+  source: drug
+  target: gene
+  input_label: DRUG_TO_GENE_ASSOCIATION

--- a/open_targets/adapter/context.py
+++ b/open_targets/adapter/context.py
@@ -155,9 +155,13 @@ class AcquisitionContext:
             view = SequenceBackedDataView(field_path_map, data, required_fields)
             sequence_data = cast("Sequence[DataView]", view[exploded_field])
             for item in sequence_data:
+                try:
+                    raw_item = item.raw_data
+                except AttributeError:
+                    raw_item = item
                 yield SequenceBackedDataView(
                     field_path_map,
-                    [*data, cast("DataViewProtocol", item).raw_data],
+                    [*data, raw_item],
                     requested_fields,
                 )
 

--- a/open_targets/adapter/context.py
+++ b/open_targets/adapter/context.py
@@ -156,7 +156,7 @@ class AcquisitionContext:
             sequence_data = cast("Sequence[DataView]", view[exploded_field])
             for item in sequence_data:
                 try:
-                    raw_item = item.raw_data
+                    raw_item = cast("DataViewProtocol", item).raw_data
                 except AttributeError:
                     raw_item = item
                 yield SequenceBackedDataView(

--- a/open_targets/adapter/data_view.py
+++ b/open_targets/adapter/data_view.py
@@ -17,7 +17,7 @@ from typing import Any, Protocol, TypeAlias, cast, overload, runtime_checkable
 
 from open_targets.data.schema_base import Field, SequenceField, StructField
 
-DataViewPrimitiveValue: TypeAlias = str | int | float | bool
+DataViewPrimitiveValue: TypeAlias = str | int | float | bool | None
 DataView: TypeAlias = Mapping[
     type[Field],
     "DataViewPrimitiveValue | DataView | Sequence[DataViewPrimitiveValue | DataView]",
@@ -153,8 +153,12 @@ class SequenceBackedDataView(DataViewProtocol, DataView):
     ) -> DataViewValue:
         field = cast("type[Field]", None)
         for field in path:
+            if data is None:
+                if issubclass(field, SequenceField):
+                    return []
+                return None
             if isinstance(data, Mapping):
-                data = data[field.name]
+                data = data.get(field.name)
             elif isinstance(data, Sequence):
                 data = data[cast("int", self._field_path_mapping[field])]
             else:

--- a/open_targets/adapter/data_view.py
+++ b/open_targets/adapter/data_view.py
@@ -17,7 +17,7 @@ from typing import Any, Protocol, TypeAlias, cast, overload, runtime_checkable
 
 from open_targets.data.schema_base import Field, SequenceField, StructField
 
-DataViewPrimitiveValue: TypeAlias = str | int | float | bool | None
+DataViewPrimitiveValue: TypeAlias = str | int | float | bool
 DataView: TypeAlias = Mapping[
     type[Field],
     "DataViewPrimitiveValue | DataView | Sequence[DataViewPrimitiveValue | DataView]",
@@ -156,9 +156,10 @@ class SequenceBackedDataView(DataViewProtocol, DataView):
             if data is None:
                 if issubclass(field, SequenceField):
                     return []
-                return None
+                msg = f"Path {path} involves a None value for field {field}."
+                raise ValueError(msg)
             if isinstance(data, Mapping):
-                data = data.get(field.name)
+                data = data[field.name]
             elif isinstance(data, Sequence):
                 data = data[cast("int", self._field_path_mapping[field])]
             else:

--- a/open_targets/adapter/data_view.py
+++ b/open_targets/adapter/data_view.py
@@ -154,10 +154,8 @@ class SequenceBackedDataView(DataViewProtocol, DataView):
         field = cast("type[Field]", None)
         for field in path:
             if data is None:
-                if issubclass(field, SequenceField):
-                    return []
-                msg = f"Path {path} involves a None value for field {field}."
-                raise ValueError(msg)
+                break
+
             if isinstance(data, Mapping):
                 data = data[field.name]
             elif isinstance(data, Sequence):

--- a/open_targets/definition/__init__.py
+++ b/open_targets/definition/__init__.py
@@ -6,6 +6,8 @@ definitions can be imported and used directly or easily derived following
 Python's dataclass practices.
 """
 
+from open_targets.definition.edge_drug_disease import edge_drug_disease
+from open_targets.definition.edge_drug_target import edge_drug_target
 from open_targets.definition.edge_target_disease import edge_target_disease
 from open_targets.definition.edge_target_go import edge_target_go
 from open_targets.definition.node_disease import node_diseases
@@ -17,6 +19,8 @@ from open_targets.definition.node_mouse_target import node_mouse_target
 from open_targets.definition.node_target import node_targets
 
 __all__ = [
+    "edge_drug_disease",
+    "edge_drug_target",
     "edge_target_disease",
     "edge_target_go",
     "node_diseases",

--- a/open_targets/definition/edge_drug_disease.py
+++ b/open_targets/definition/edge_drug_disease.py
@@ -20,7 +20,6 @@ from open_targets.data.schema import (
     FieldMoleculeLinkedDiseasesRowsElement,
 )
 from open_targets.definition.curie_prefix import CHEMBL_PREFIX
-
 from open_targets.definition.node_shared import node_static_properties
 
 edge_drug_disease: Final[AcquisitionDefinition[EdgeInfo]] = ExpressionEdgeAcquisitionDefinition(
@@ -47,5 +46,4 @@ edge_drug_disease: Final[AcquisitionDefinition[EdgeInfo]] = ExpressionEdgeAcquis
     target=NormaliseCurieExpression(ToStringExpression(FieldExpression(FieldMoleculeLinkedDiseasesRowsElement))),
     label=LiteralExpression("DRUG_TO_DISEASE_ASSOCIATION"),
     properties=node_static_properties,
-    
 )

--- a/open_targets/definition/edge_drug_disease.py
+++ b/open_targets/definition/edge_drug_disease.py
@@ -1,0 +1,51 @@
+"""Acquisition definition that acquires edges between drugs (molecules) and diseases using linkedDiseases."""
+
+from typing import Final
+
+from open_targets.adapter.acquisition_definition import AcquisitionDefinition, ExpressionEdgeAcquisitionDefinition
+from open_targets.adapter.expression import (
+    BuildCurieExpression,
+    FieldExpression,
+    LiteralExpression,
+    NormaliseCurieExpression,
+    StringConcatenationExpression,
+    ToStringExpression,
+)
+from open_targets.adapter.output import EdgeInfo
+from open_targets.adapter.scan_operation import ExplodingScanOperation
+from open_targets.data.schema import (
+    DatasetMolecule,
+    FieldMoleculeId,
+    FieldMoleculeLinkedDiseasesRows,
+    FieldMoleculeLinkedDiseasesRowsElement,
+)
+from open_targets.definition.curie_prefix import CHEMBL_PREFIX
+
+from open_targets.definition.node_shared import node_static_properties
+
+edge_drug_disease: Final[AcquisitionDefinition[EdgeInfo]] = ExpressionEdgeAcquisitionDefinition(
+    scan_operation=ExplodingScanOperation(
+        dataset=DatasetMolecule,
+        exploded_field=FieldMoleculeLinkedDiseasesRows,
+    ),
+    primary_id=StringConcatenationExpression(
+        expressions=[
+            BuildCurieExpression(
+                prefix=LiteralExpression(CHEMBL_PREFIX),
+                reference=FieldExpression(FieldMoleculeId),
+                normalise=True,
+            ),
+            LiteralExpression("->"),
+            NormaliseCurieExpression(ToStringExpression(FieldExpression(FieldMoleculeLinkedDiseasesRowsElement))),
+        ],
+    ),
+    source=BuildCurieExpression(
+        prefix=LiteralExpression(CHEMBL_PREFIX),
+        reference=FieldExpression(FieldMoleculeId),
+        normalise=True,
+    ),
+    target=NormaliseCurieExpression(ToStringExpression(FieldExpression(FieldMoleculeLinkedDiseasesRowsElement))),
+    label=LiteralExpression("DRUG_TO_DISEASE_ASSOCIATION"),
+    properties=node_static_properties,
+    
+)

--- a/open_targets/definition/edge_drug_target.py
+++ b/open_targets/definition/edge_drug_target.py
@@ -1,0 +1,55 @@
+"""Acquisition definition that acquires edges between drugs (molecules) and genes (targets) using the known drug dataset."""
+
+from typing import Final
+
+from open_targets.adapter.acquisition_definition import AcquisitionDefinition, ExpressionEdgeAcquisitionDefinition
+from open_targets.adapter.expression import (
+    BuildCurieExpression,
+    FieldExpression,
+    LiteralExpression,
+    StringConcatenationExpression,
+)
+from open_targets.adapter.output import EdgeInfo
+from open_targets.adapter.scan_operation import ExplodingScanOperation
+from open_targets.data.schema import (
+    DatasetMolecule,
+    FieldMoleculeId,
+    FieldMoleculeLinkedTargetsRows,
+    FieldMoleculeLinkedTargetsRowsElement,
+)
+from open_targets.definition.curie_prefix import CHEMBL_PREFIX, ENSEMBL_PREFIX
+from open_targets.definition.node_shared import node_static_properties
+
+edge_drug_target: Final[AcquisitionDefinition[EdgeInfo]] = ExpressionEdgeAcquisitionDefinition(
+    scan_operation=ExplodingScanOperation(
+        dataset=DatasetMolecule,
+        exploded_field=FieldMoleculeLinkedTargetsRows,
+    ),
+    primary_id=StringConcatenationExpression(
+        expressions=[
+            BuildCurieExpression(
+                prefix=LiteralExpression(CHEMBL_PREFIX),
+                reference=FieldExpression(FieldMoleculeId),
+                normalise=True,
+            ),
+            LiteralExpression("->"),
+            BuildCurieExpression(
+        prefix=LiteralExpression(ENSEMBL_PREFIX),
+        reference=FieldExpression(FieldMoleculeLinkedTargetsRowsElement),
+        normalise=True,
+    ),
+        ],
+    ),
+    source=BuildCurieExpression(
+        prefix=LiteralExpression(CHEMBL_PREFIX),
+        reference=FieldExpression(FieldMoleculeId),
+        normalise=True,
+    ),
+    target=BuildCurieExpression(
+        prefix=LiteralExpression(ENSEMBL_PREFIX),
+        reference=FieldExpression(FieldMoleculeLinkedTargetsRowsElement),
+        normalise=True,
+    ),
+    label=LiteralExpression("DRUG_TO_GENE_ASSOCIATION"),
+    properties=node_static_properties,
+)

--- a/open_targets/definition/edge_drug_target.py
+++ b/open_targets/definition/edge_drug_target.py
@@ -34,10 +34,10 @@ edge_drug_target: Final[AcquisitionDefinition[EdgeInfo]] = ExpressionEdgeAcquisi
             ),
             LiteralExpression("->"),
             BuildCurieExpression(
-        prefix=LiteralExpression(ENSEMBL_PREFIX),
-        reference=FieldExpression(FieldMoleculeLinkedTargetsRowsElement),
-        normalise=True,
-    ),
+                prefix=LiteralExpression(ENSEMBL_PREFIX),
+                reference=FieldExpression(FieldMoleculeLinkedTargetsRowsElement),
+                normalise=True,
+            ),
         ],
     ),
     source=BuildCurieExpression(

--- a/scripts/open_targets_biocypher_run.py
+++ b/scripts/open_targets_biocypher_run.py
@@ -6,10 +6,10 @@ from biocypher import BioCypher
 
 from open_targets.adapter.context import AcquisitionContext
 from open_targets.definition import (
-    edge_target_disease,
-    edge_target_go,
     edge_drug_disease,
     edge_drug_target,
+    edge_target_disease,
+    edge_target_go,
     node_diseases,
     node_gene_ontology,
     node_molecule,
@@ -37,11 +37,7 @@ def main():
         node_mouse_phenotype,
         node_mouse_target,
     ]
-    edge_definitions = [
-        edge_target_disease, 
-        edge_target_go, 
-        edge_drug_disease, 
-        edge_drug_target]
+    edge_definitions = [edge_target_disease, edge_target_go, edge_drug_disease, edge_drug_target]
 
     # Open Targets
     context = AcquisitionContext(

--- a/scripts/open_targets_biocypher_run.py
+++ b/scripts/open_targets_biocypher_run.py
@@ -8,6 +8,8 @@ from open_targets.adapter.context import AcquisitionContext
 from open_targets.definition import (
     edge_target_disease,
     edge_target_go,
+    edge_drug_disease,
+    edge_drug_target,
     node_diseases,
     node_gene_ontology,
     node_molecule,
@@ -35,7 +37,11 @@ def main():
         node_mouse_phenotype,
         node_mouse_target,
     ]
-    edge_definitions = [edge_target_disease, edge_target_go]
+    edge_definitions = [
+        edge_target_disease, 
+        edge_target_go, 
+        edge_drug_disease, 
+        edge_drug_target]
 
     # Open Targets
     context = AcquisitionContext(


### PR DESCRIPTION
Added the acquisition logic for `drug to gene` and `drug to disease` associations.
The dataset (FieldMoleculeLinkedDiseasesRowsElement) is of type array[str] which could not be handled natively, so I had to update the processing a bit.

Let me know if there is a better way to handle this!